### PR TITLE
bug: Switched from uNetworking/uWS to hoytech/uWS

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -23,7 +23,7 @@ endfunction(downloadFile)
 downloadFile(   "https://api.github.com/repos/hoytech/uWebSockets/tarball/master"
                 "${CMAKE_SOURCE_DIR}/deps/uWebSockets.tar.gz"
                 SHA256
-                d51301a9a0b36d6ec531b3ce867cf9c343978abc137e39d217524cb8e6d9d0dd
+                40ecedbdd2fb5b6f69f06e8830e9139dc290c3125d1eb1f3449b9fd9277b50c8
             )
 
 #Download GTest

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -20,10 +20,10 @@ endif()
 endfunction(downloadFile)
 
 #Download uWS v0.14
-downloadFile(   "https://github.com/uNetworking/uWebSockets/archive/v0.14.8.tar.gz"
-                "${CMAKE_SOURCE_DIR}/deps/uWebSocketsv-0.14.8.tar.gz"
+downloadFile(   "https://api.github.com/repos/hoytech/uWebSockets/tarball/master"
+                "${CMAKE_SOURCE_DIR}/deps/uWebSockets.tar.gz"
                 SHA256
-                663a22b521c8258e215e34e01c7fcdbbd500296aab2c31d36857228424bb7675
+                d51301a9a0b36d6ec531b3ce867cf9c343978abc137e39d217524cb8e6d9d0dd
             )
 
 #Download GTest


### PR DESCRIPTION
`cmake .` in `deps` will now install https://github.com/hoytech/uWebSockets -- a fork of uWebSockets with some improvements, most important one being an improved Makefile. It installs the library in `/usr/local/` and fixes #24.

Tests pass, but **it is important someone tests this live before merging**. I'm not subscribed to KiteConnect at the moment.