### PR TITLE
fix: switch to homebrew/cask-versions

### DIFF
--- a/.github/workflows/cppkiteconnect-test.yml
+++ b/.github/workflows/cppkiteconnect-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build and test on macOS
         if: startsWith(matrix.config.name, 'macOS')
         run: |
-          brew extract --version=1.10.0 googletest homebrew/cask && brew install googletest@1.10.0 libuv
+          brew extract --version=1.10.0 googletest homebrew/cask-versions && brew install googletest@1.10.0 libuv
           export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
 
           curl -L https://github.com/hoytech/uWebSockets/archive/refs/tags/v0.14.8.tar.gz > uWebSocketsv-0.14.8.tar.gz


### PR DESCRIPTION
It seems extracting to `homebrew/cask` is no longer supported. We have to use `homebrew/cask-versions` for older versions of a tap.

Fixes #68 